### PR TITLE
[FE] Header 수정

### DIFF
--- a/src/components/Header/Logo/index.jsx
+++ b/src/components/Header/Logo/index.jsx
@@ -4,7 +4,7 @@ import * as S from "./index.styled";
 function Logo() {
   return (
     <S.Container>
-      <S.Logo>Project</S.Logo>
+      <S.Header>Project</S.Header>
     </S.Container>
   );
 }

--- a/src/components/Header/Logo/index.jsx
+++ b/src/components/Header/Logo/index.jsx
@@ -4,7 +4,7 @@ import * as S from "./index.styled";
 function Logo() {
   return (
     <S.Container>
-      <S.Header>Project</S.Header>
+      <S.StyledLink to={"/"}>쇼핑몰</S.StyledLink>
     </S.Container>
   );
 }

--- a/src/components/Header/Logo/index.styled.js
+++ b/src/components/Header/Logo/index.styled.js
@@ -1,14 +1,19 @@
 import styled from "@emotion/styled";
+import { Link } from "react-router-dom";
 
 const Container = styled.div`
+  display: flex;
+  justify-content: center;
   width: 20vw;
 `;
 
-const Header = styled.h1`
+const StyledLink = styled(Link)`
   display: flex;
   align-items: center;
-  justify-content: center;
+
+  font-size: 2rem;
   color: #0f010d;
+  text-decoration: none;
 `;
 
-export { Container, Header };
+export { Container, StyledLink };

--- a/src/components/Header/Logo/index.styled.js
+++ b/src/components/Header/Logo/index.styled.js
@@ -1,17 +1,14 @@
 import styled from "@emotion/styled";
 
 const Container = styled.div`
-  position: absolute;
-  width: 25vh;
-  width: 15%;
-  height: 100px;
+  width: 20vw;
 `;
 
-const Logo = styled.h1`
+const Header = styled.h1`
   display: flex;
   align-items: center;
   justify-content: center;
   color: #0f010d;
 `;
 
-export { Container, Logo };
+export { Container, Header };

--- a/src/components/Header/Nav/index.jsx
+++ b/src/components/Header/Nav/index.jsx
@@ -6,15 +6,9 @@ import * as S from "./index.styled";
 function Nav() {
   return (
     <S.Container>
-      <S.TextContainer>
-        <S.StyledLink to={"/product"}>Product</S.StyledLink>
-      </S.TextContainer>
-      <S.TextContainer>
-        <S.StyledLink to={"/outfit"}>Outfit</S.StyledLink>
-      </S.TextContainer>
-      <S.TextContainer>
-        <S.StyledLink to={"/review"}>Review</S.StyledLink>
-      </S.TextContainer>
+      <S.StyledLink to={"/product"}>Product</S.StyledLink>
+      <S.StyledLink to={"/outfit"}>Outfit</S.StyledLink>
+      <S.StyledLink to={"/review"}>Review</S.StyledLink>
     </S.Container>
   );
 }

--- a/src/components/Header/Nav/index.styled.js
+++ b/src/components/Header/Nav/index.styled.js
@@ -2,33 +2,21 @@ import styled from "@emotion/styled";
 import { Link } from "react-router-dom";
 
 const Container = styled.div`
-  position: absolute;
   display: flex;
-  margin-left: 15%;
-  width: 30%;
-  height: 100px;
-`;
-
-const TextContainer = styled.div`
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  overflow: hidden;
-  width: 25%;
-  transition: all 0.3s;
-  &: hover {
-    transform: scale(1.1);
-  }
+  justify-content: space-around;
+  width: 20vw;
 `;
 
 const StyledLink = styled(Link)`
   display: flex;
   align-items: center;
-  justify-content: center;
-  margin: 5px;
   color: #0f010d;
-
   text-decoration: none;
+  transition: all 0.3s;
+
+  &: hover {
+    transform: scale(1.1);
+  }
 `;
 
-export { Container, TextContainer, StyledLink };
+export { Container, StyledLink };

--- a/src/components/Header/Search/index.jsx
+++ b/src/components/Header/Search/index.jsx
@@ -2,6 +2,10 @@ import React from "react";
 import * as S from "./index.styled";
 
 function Search() {
-  return <S.Container>{/* <h1>Search</h1> */}</S.Container>;
+  return (
+    <S.Container>
+      <h1>Search</h1>
+    </S.Container>
+  );
 }
 export default Search;

--- a/src/components/Header/Search/index.jsx
+++ b/src/components/Header/Search/index.jsx
@@ -1,10 +1,35 @@
-import React from "react";
+import React, { useState } from "react";
+
+import { TextField } from "@mui/material";
 import * as S from "./index.styled";
+import { useNavigate } from "react-router-dom";
 
 function Search() {
+  const [value, setValue] = useState({});
+  const navigate = useNavigate();
+
+  const getValue = (e) => {
+    setValue(e.target.value);
+  };
+
+  const handleOnKeyPress = (e) => {
+    if (e.key === "Enter") {
+      navigate(`/product?search=${value}`);
+    }
+  };
+
   return (
     <S.Container>
-      <h1>Search</h1>
+      <S.Wrapper>
+        <TextField
+          fullWidth
+          id="value"
+          label="제품명을 입력하세요."
+          variant="standard"
+          onChange={getValue}
+          onKeyDown={handleOnKeyPress}
+        />
+      </S.Wrapper>
     </S.Container>
   );
 }

--- a/src/components/Header/Search/index.jsx
+++ b/src/components/Header/Search/index.jsx
@@ -1,8 +1,9 @@
 import React, { useState } from "react";
+import { useNavigate } from "react-router-dom";
 
 import { TextField } from "@mui/material";
+
 import * as S from "./index.styled";
-import { useNavigate } from "react-router-dom";
 
 function Search() {
   const [value, setValue] = useState({});
@@ -15,6 +16,7 @@ function Search() {
   const handleOnKeyPress = (e) => {
     if (e.key === "Enter") {
       navigate(`/product?search=${value}`);
+      e.target.value = null;
     }
   };
 

--- a/src/components/Header/Search/index.styled.js
+++ b/src/components/Header/Search/index.styled.js
@@ -7,4 +7,9 @@ const Container = styled.div`
   width: 40vw;
 `;
 
-export { Container };
+const Wrapper = styled.div`
+  width: 60%;
+  margin-bottom: 3%;
+`;
+
+export { Container, Wrapper };

--- a/src/components/Header/Search/index.styled.js
+++ b/src/components/Header/Search/index.styled.js
@@ -1,11 +1,10 @@
 import styled from "@emotion/styled";
 
 const Container = styled.div`
-  position: absolute;
-  margin-left: 45%;
-  width: 30%;
-  height: 100px;
-  // background-color: purple;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 40vw;
 `;
 
 export { Container };

--- a/src/components/Header/User/index.jsx
+++ b/src/components/Header/User/index.jsx
@@ -1,28 +1,11 @@
 import React from "react";
 import * as S from "./index.styled";
-import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { faBasketShopping } from "@fortawesome/free-solid-svg-icons";
-import { faHeart } from "@fortawesome/free-solid-svg-icons";
-import { faUser } from "@fortawesome/free-solid-svg-icons";
 
 function User() {
   return (
     <S.Container>
-      <S.IconContainer>
-        <S.StyledLink>
-          <FontAwesomeIcon icon={faHeart} />
-        </S.StyledLink>
-      </S.IconContainer>
-      <S.IconContainer>
-        <S.StyledLink to={"/cart"}>
-          <FontAwesomeIcon icon={faBasketShopping} />
-        </S.StyledLink>
-      </S.IconContainer>
-      <S.IconContainer>
-        <S.StyledLink to={"/my"}>
-          <FontAwesomeIcon icon={faUser} />
-        </S.StyledLink>
-      </S.IconContainer>
+      <S.StyledLink to={"/cart"}>Cart</S.StyledLink>
+      <S.StyledLink to={"/login"}>Login</S.StyledLink>
     </S.Container>
   );
 }

--- a/src/components/Header/User/index.jsx
+++ b/src/components/Header/User/index.jsx
@@ -1,11 +1,21 @@
 import React from "react";
 import * as S from "./index.styled";
 
-function User() {
+// isLogin : Boolean
+function User({ isLogin }) {
+  // isLogin = true;
+  if (isLogin) {
+    return (
+      <S.Container>
+        <S.StyledLink to={"/cart"}>Cart</S.StyledLink>
+        <S.StyledLink to={"/my"}>MyPage</S.StyledLink>
+      </S.Container>
+    );
+  }
   return (
     <S.Container>
-      <S.StyledLink to={"/cart"}>Cart</S.StyledLink>
-      <S.StyledLink to={"/login"}>Login</S.StyledLink>
+      <S.StyledLink to={"/login"}>Cart</S.StyledLink>
+      <S.StyledLink to={"/login"}>MyPage</S.StyledLink>
     </S.Container>
   );
 }

--- a/src/components/Header/User/index.styled.js
+++ b/src/components/Header/User/index.styled.js
@@ -4,31 +4,20 @@ import { Link } from "react-router-dom";
 const Container = styled.div`
   display: flex;
   align-items: center;
-  justify-content: center;
-
-  margin-left: 75%;
-  width: 25%;
-  height: 100px;
-`;
-
-const IconContainer = styled.div`
-  display: flex;
-  align-items: center;
-  justify-content: center;
-
-  width: 25%;
-  height: 50%;
-  float: left;
+  justify-content: space-around;
+  width: 20vw;
 `;
 
 const StyledLink = styled(Link)`
+  display: flex;
+  align-items: center;
   color: #0f010d;
-  transform: scale(1.1);
-
+  text-decoration: none;
   transition: all 0.3s;
+
   &: hover {
-    transform: scale(1.3);
+    transform: scale(1.1);
   }
 `;
 
-export { Container, IconContainer, StyledLink };
+export { Container, StyledLink };

--- a/src/components/Header/index.jsx
+++ b/src/components/Header/index.jsx
@@ -5,13 +5,13 @@ import Nav from "./Nav";
 import Search from "./Search";
 import User from "./User";
 
-function Header({ children }) {
+function Header() {
   return (
     <>
       <S.Container>
         <Logo />
         <Nav />
-        <Search /> {/*추후 검색 기능 개발*/}
+        <Search />
         <User />
       </S.Container>
     </>

--- a/src/components/Header/index.styled.js
+++ b/src/components/Header/index.styled.js
@@ -2,11 +2,10 @@ import styled from "@emotion/styled";
 
 const Container = styled.div`
   position: absolute;
+  display: flex;
   width: 100%;
-  height: 100px;
-
+  height: 80px;
   background-color: #f8f8f8;
-
   z-index: 999;
 `;
 

--- a/src/components/Header/index.styled.js
+++ b/src/components/Header/index.styled.js
@@ -1,7 +1,7 @@
 import styled from "@emotion/styled";
 
 const Container = styled.div`
-  position: absolute;
+  position: fixed;
   display: flex;
   width: 100%;
   height: 80px;

--- a/src/layouts/pages/index.styled.js
+++ b/src/layouts/pages/index.styled.js
@@ -6,7 +6,7 @@ const PageContainer = styled.div`
 
 const Content = styled.div`
   min-height: 824px;
-  padding-top: 100px;
+  padding-top: 80px;
 `;
 
 export { PageContainer, Content };


### PR DESCRIPTION
# 개요

#45 

## 작업사항

- [x] 로고 중앙 정렬
<img width="676" alt="2023-03-11_19-09-04" src="https://user-images.githubusercontent.com/74192619/224478396-80ae613b-c37f-485d-a972-78eaf059cb31.png">

- [x] 로그인 유무에 따라서 로그인 또는 사용자의 닉네임을 출력하는 버튼 생성
- [x]  아이콘 삭제후 텍스트로 대치
<img width="357" alt="2023-03-11_19-10-15" src="https://user-images.githubusercontent.com/74192619/224478444-a986ac6a-fbe6-4749-a1e0-3fead89ecba0.png">

- [x] 검색이 가능하게 폼 기능 구현
- [x] 페이지 스크롤시 Header를 고정

## 기타
![example](https://user-images.githubusercontent.com/74192619/224531064-52175c0a-572d-4afc-9edc-94435e80454b.gif)


