### PR TITLE
[FE] Header 수정

### DIFF
--- a/src/components/Header/User/index.jsx
+++ b/src/components/Header/User/index.jsx
@@ -1,13 +1,41 @@
-import React from "react";
+import React, { useCallback, useEffect, useState } from "react";
+import axios from "axios";
 import * as S from "./index.styled";
 
 // isLogin : Boolean
 function User({ isLogin }) {
   isLogin = true;
+
+  const [data, setData] = useState("");
+
+  // TODO: 추후 API SERVER의 URL로 변경
+  const getData = useCallback(async () => {
+    await axios
+      .get(`http://localhost:4000/header`)
+      .then((response) => {
+        setData(response.data);
+      })
+      .catch((error) => {
+        console.error(error);
+      });
+  }, []);
+
+  console.log(data);
+
+  useEffect(() => {
+    getData();
+  }, [getData]);
+
   if (isLogin) {
     return (
       <S.Container>
-        <S.StyledLink to={"/cart"}>Cart</S.StyledLink>
+        <S.StyledLink to={"/cart"}>
+          Cart
+          <S.Wrapper>
+            {/* TODO: 추후 배열형태가 아닌 객체 형태로 들어오므로 수정 필요 */}
+            <span>{data[0].cartCount}</span>
+          </S.Wrapper>
+        </S.StyledLink>
         <S.StyledLink to={"/my"}>MyPage</S.StyledLink>
       </S.Container>
     );

--- a/src/components/Header/User/index.styled.js
+++ b/src/components/Header/User/index.styled.js
@@ -20,4 +20,15 @@ const StyledLink = styled(Link)`
   }
 `;
 
-export { Container, StyledLink };
+const Wrapper = styled.div`
+  background-color: #e5cdce;
+  width: 20px;
+  height: 20px;
+  border-radius: 100%;
+  opacity: 0.66;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+`;
+
+export { Container, Wrapper, StyledLink };

--- a/src/data/data.json
+++ b/src/data/data.json
@@ -1,0 +1,50 @@
+{
+    "header": [
+        {
+            "user_id": 1,
+            "name": "홍길동",
+            "cartCount": 3
+        }
+    ],
+    "my": [
+        {
+            "user_id": 1,
+            "name": "홍길동",
+            "email": "project0109@gmail.com",
+            "phone_number": "010-1234-5678",
+            "recipient": "홍길동",
+            "zip_code": 12345,
+            "address": "서울시 강남구 어딘가",
+            "count": 3,
+            "orders": [
+                {
+                    "date": "2023-03-09",
+                    "id": 1,
+                    "productInfo": "데님 자켓",
+                    "productId": "1",
+                    "productOption": "S",
+                    "price": 89000,
+                    "status": "결제"
+                },
+                {
+                    "date": "2023-03-10",
+                    "id": 2,
+                    "productInfo": "청바지",
+                    "productId": "2",
+                    "productOption": "M",
+                    "price": 109000,
+                    "status": "취소"
+                },
+                {
+                    "date": "2023-03-10",
+                    "id": 3,
+                    "productInfo": "가죽 자켓",
+                    "productId": "3",
+                    "productOption": "L",
+                    "price": 119000,
+                    "status": "결제"
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION

# 개요

전체 장바구니 옆에 숫자가 카운터 되는 것을 추가하면 좋겠다는 피드백(@paul3148 )이 있어서 추가하였다.

## 작업사항

- [X] API get 기능 추가
- [X] 장바구니 옆에 현재 장바구니에 담긴 목록의 개수 출력 기능 추가
<img width="342" alt="2023-03-13_22-23-50" src="https://user-images.githubusercontent.com/74192619/224715185-cc458e31-1746-42f3-865f-55ef4e84b878.png">

